### PR TITLE
fix: Extraction of `selectedIssue` Parameter from URL

### DIFF
--- a/scripts/copybtn.js
+++ b/scripts/copybtn.js
@@ -5,8 +5,13 @@ function getIssueId() {
   let issueKey;
 
   if (document.URL.includes(searchParam)) {
-    let match = document.URL.match(/\&selectedIssue=(.*?)(?=&|$)/)[1];
-    issueKey = match;
+    let match = document.URL.match(/[?&][selectedIssue]=([^&]*)/);
+    if (match) {
+      issueKey = match[1];
+      console.log(issueKey);
+    } else {
+      console.error("Failed to extract the 'selectedIssue' in the URL.");
+    }
   } else {
     let match = document.title.match(/\[(.*?)\]/)[1];
     issueKey = match;


### PR DESCRIPTION
#### **Summary**
This PR improve the extraction of the `selectedIssue` parameter from the URL.

#### **Changes Made**
1. Updated the regex for extracting `selectedIssue` from the URL to use a more precise pattern: `/[?&][selectedIssue]=([^&]*)/`.
2. Added a conditional check to handle cases where `selectedIssue` is not found in the URL:
   - Logs the `issueKey` to the console if extraction is successful.
   - Logs an error message to the console if the extraction fails.

#### **Why This Change?**
- The previous implementation didn't work on Jira boards view.
