### PR TITLE
Add new parent node selector for copy button

### DIFF
--- a/scripts/copybtn.js
+++ b/scripts/copybtn.js
@@ -85,7 +85,8 @@ var observer = new MutationObserver(function (mutations, me) {
   var parent = document.getElementsByClassName('gn0msi-0 cqZBrb')[0] ??
                document.getElementsByClassName('_otyr1y44 _ca0q1y44 _u5f3idpf _n3td1y44 _19bvidpf _1e0c116y')[0] ??
                document.getElementsByClassName('_otyr1b66 _1yt4swc3 _1e0c116y')[0] ??
-               document.getElementsByClassName('_otyr1b66 _19pk1b66 _ca0q1b66 _u5f3idpf _n3td1b66 _19bvidpf _1e0c116y')[0];
+               document.getElementsByClassName('_otyr1b66 _19pk1b66 _ca0q1b66 _u5f3idpf _n3td1b66 _19bvidpf _1e0c116y')[0] ??
+               document.getElementsByClassName('css-1pjflpu')[0];
   if (parent) {
     if (!document.getElementById('CopyBtnJiraId')) {
       createButton(parent);


### PR DESCRIPTION
After the last Jira update, the parent node is now not located according to the current selectors